### PR TITLE
feat: return int256[] in evm-price-feed op

### DIFF
--- a/examples/evm-price-feed/README.md
+++ b/examples/evm-price-feed/README.md
@@ -47,19 +47,19 @@ No additional input is required for this Oracle Program as the Tally Phase only 
 
 1. Collects all price reveals from oracle nodes.
 1. Calculates the median price for each trading pair.
-1. ABI-encodes the result as `uint256[]` for EVM compatibility.
+1. ABI-encodes the result as `int256[]` for EVM compatibility.
 1. Posts the final result.
 
 ### Output Format
 
-The result is ABI-encoded as `uint256[]` where each element represents the median price of the corresponding trading pair in the input order.
+The result is ABI-encoded as `int256[]` where each element represents the median price of the corresponding trading pair in the input order.
 
 ### Example
 If the execution phase processed `["BTC-USD", "ETH-USD"]` and the median prices were:
 - BTC-USD: $45,000.00 (45000000000 in 6 decimals)
 - ETH-USD: $2,800.00 (2800000000 in 6 decimals)
 
-The tally phase would return: `[45000000000, 2800000000]` ABI-encoded as `uint256[]`.
+The tally phase would return: `[45000000000, 2800000000]` ABI-encoded as `int256[]`.
 
 ## Supported Trading Pairs
 

--- a/examples/evm-price-feed/src/tally_phase.rs
+++ b/examples/evm-price-feed/src/tally_phase.rs
@@ -77,6 +77,6 @@ fn median_each_asset(data: &[Vec<u128>]) -> Result<Vec<Token>> {
             vals.sort();
             median_sorted(&vals)
         })
-        .map(|p| Token::Uint(U256::from(p)))
+        .map(|p| Token::Int(U256::from(p)))
         .collect())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -422,7 +422,7 @@ fn post_evm_price_feed(cmd: Cmd<'_>, symbols: &str) -> std::result::Result<(), a
     cmd.arg("--exec-inputs")
         .arg(symbols)
         .arg("--decode-abi")
-        .arg("uint256[]")
+        .arg("int256[]")
         .arg("--encode-exec-inputs")
         .arg("string[]")
         .run()?;


### PR DESCRIPTION
## Motivation

EVM contracts implementing standard price feed interfaces use `int256` for price values.
This avoids having to cast from uint256 to int256, which theoretically could overflow (but not really because we were handling uint128).

## Explanation of Changes

Change return type to `itn256[]`.

## Testing

- Tested locally: `cargo test-op evm-price-feed `/
- Tested on testnet: `cargo post-dr evm-price-feed \[\"BTC-USDT\"\] -i 81dd9fce37e9f2ad1265b876185f0a28e8b180da9162f4c93c6b2037570ed082`
- Tested integration with `seda-pricefeed-adapter` repository

## Related PRs and Issues

N/A
