### PR TITLE
feat(blocksize): refactor with the changes they asked for

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ In a quick overview:
 
 Clink the links below to learn how to quickly post a Data Request specifically for each example, however, please check out the [requirements](#requirements) before posting a Data Request with the examples:
 
+- [Blocksize Bidask](./examples/blocksize-bidask/README.md#overview)
+- [Blocksize VWAP](./examples/blocksize-vwap/README.md#overview)
 - [Caplight Eod Market Price](./examples/caplight-eod-market-price/README.md#overview)
 - [Single Commodity Price](./examples/single-commodity-price/README.md#overview)
 - [Single Equity Price](./examples/single-equity-price/README.md#overview)
@@ -46,6 +48,8 @@ Make sure the tools below are installed and in your `PATH` if you want to build,
 
 Please find a few example Oracle Programs here:
 
+- [Blocksize Bidask](./examples/blocksize-bidask/README.md): Receives the latest aggregated bid ask for one pair from the Blocksize API behind a Data Proxy.
+- [Blocksize VWAP](./examples/blocksize-vwap/README.md): Receives the latest volume weighted average price for one pair from the Blocksize API behind a Data Proxy.
 - [Caplight Eod Market Price](./examples/caplight-eod-market-price/README.md): A way to ask for the market price history for a company leveraging the Caplight API behind a data proxy.
 - [Single Commodity Price](./examples/single-commodity-price/README.md): A way to get the price of a commodity using the dxFeed API behind a Data Proxy.
 - [Single Equity Price](./examples/single-commodity-price/README.md): A way to get the price of an equity using the dxFeed API behind a Data Proxy.

--- a/examples/blocksize-bidask/README.md
+++ b/examples/blocksize-bidask/README.md
@@ -1,7 +1,7 @@
 # Blocksize Bid Ask
 
 Deployments:
-- [Testnet](https://testnet.explorer.seda.xyz/oracle-programs/67d72c90bff19765b751aaad7b550d7c488390d1e042f02d7395401dece565bb)
+- [Testnet](https://testnet.explorer.seda.xyz/oracle-programs/0befce19a31a9bb01ba0c3ed04d134498b0e55f356590103e8bd7f20a02ac582)
 <!-- - [Mainnet](https://explorer.seda.xyz/oracle-programs/) -->
 
 
@@ -12,37 +12,43 @@ This Oracle Program gets the price of a price pair using the Blocksize API and r
 You can test this Oracle Program on testnet with the following command:
 
 ```sh
-cargo post-dr blocksize-bidask ETHUSD -i 67d72c90bff19765b751aaad7b550d7c488390d1e042f02d7395401dece565bb --gas-price 4000
+cargo post-dr blocksize-bidask ETHUSD -i 0befce19a31a9bb01ba0c3ed04d134498b0e55f356590103e8bd7f20a02ac582 --gas-price 4000
 ```
 
 ## Execution Phase:
 
 ### Input Format
 
-The Execution Phase expects a price pair symbol, and optionally the field from the response to use. By default it will use the `agg_ask_price` field from the API response.
+The Execution Phase expects a price pair symbol, and optionally the field from the response to use. By default it will use all the fields from the API response.
 
 ### Process
 
 1. Validates the Data Request execution argument is not empty.
+1. The inputs are validated.
 1. Makes a HTTP call to the Blocksize Data Proxy.
-1. Converts the decimal to a `u128` with 2 decimal precision.
-1. Returns the `u128` in little endian format.
+1. Converts the decimal to a `u128` with 6 decimal precision.
+1. Returns an array of bytes that is the fields in the specified order each in little endian format.
 
 ### Examples
 
-#### With No Field
+#### With No Fields Specified
 
 Input: `ETHUSD`
 
-Output: `4537066188`
+Output: `[4326346792, 74548932, 4326410335, 127739791, 4326378563, 1757023918380518]`
 
 
-#### With a Field
+#### With a Field Specified
 
 Input: `ETHUSD-agg_bid_price`
 
-Output: `4362597230`
+Output: `[4362597230]`
 
+#### With a Fields Specified
+
+Input: `ETHUSD-ts,agg_bid_price`
+
+Output: `[1757023918380518 4362597230]`
 
 ## Tally Phase
 
@@ -55,20 +61,34 @@ No additional input is required for this Oracle Program as the Tally Phase only 
 1. Collects all price reveals from oracle nodes.
 1. Calculates the median price from all the given prices.
 1. ABI-encodes the result as a `uint256` for EVM compatibility.
-1. Posts the final result.
+1. Posts the final result preserving the order of the fields asked for.
 
 ### Output Format
 
-The result is ABI-encoded as `uint256` where the final number is the median of all the collected price data.
+The result is ABI-encoded as `uint256[]` where the final number is the median of all the collected price data.
 
 ### Example
 
 If execution phase ran with a replication factor of 2 and the prices were:
-- 100
-- 200
+- [100]
+- [200]
 
-The tally phase would return `150` ABI-encoded as a `uint256`.
+The tally phase would return `[150]` ABI-encoded as a `uint256[]`.
 
 ## Supported Data
 
 This supports any price pair supported by the [Blocksize API](https://realtime.blocksize.dev/docs#/Bid%20Ask).
+
+For quick reference, the JSON response is as follows:
+
+```JSON
+{
+  "ticker": "ETHUSD",
+  "agg_bid_price": "4362.597230371793",
+  "agg_bid_size": "98.42767488000001",
+  "agg_ask_price": "4364.092969924804",
+  "agg_ask_size": "125.29260208",
+  "agg_mid_price": "4363.345100148298",
+  "ts": 1756156227634385
+}
+```

--- a/examples/blocksize-bidask/src/execution_phase.rs
+++ b/examples/blocksize-bidask/src/execution_phase.rs
@@ -28,6 +28,17 @@ pub fn execution_phase() -> Result<()> {
 //   "ts": 1756156227634385
 // }
 
+const VALID_FIELDS: &[&str] = &[
+    "agg_bid_price",
+    "agg_bid_size",
+    "agg_ask_price",
+    "agg_ask_size",
+    "agg_mid_price",
+    "ts",
+];
+
+// do all fields by default
+// return a uint256[] abi encoded in tally
 #[cfg(any(feature = "testnet", feature = "mainnet"))]
 pub fn execution_phase() -> Result<()> {
     use seda_sdk_rs::HttpFetchOptions;
@@ -36,7 +47,7 @@ pub fn execution_phase() -> Result<()> {
     unimplemented!("Mainnet not yet supported");
 
     // Expected to be in the format "symbol" (e.g., "ETHUSD" or "BTCUSD").
-    // Optionally followed by the field name (e.g., "agg_ask_price") separated by a hyphen(-).
+    // Optionally followed by the field names (e.g., "agg_ask_price,agg_mid_price") separated by a hyphen(-).
     let dr_inputs_raw = String::from_utf8(Process::get_inputs())?;
     if dr_inputs_raw.is_empty() {
         // If no input is provided, log an error and return.
@@ -46,19 +57,34 @@ pub fn execution_phase() -> Result<()> {
     }
 
     let parts: Vec<&str> = dr_inputs_raw.split('-').collect();
-    let (pair, field) = match parts.as_slice() {
-        [pair, field] => (pair, *field),
-        [pair] => (pair, "agg_ask_price"),
+    let (pair, fields) = match parts.as_slice() {
+        // validate that each field is in the valid fields list
+        [pair, fields] => (
+            pair,
+            fields
+                .split(',')
+                .filter(|field| {
+                    let in_map = VALID_FIELDS.contains(field);
+                    if !in_map {
+                        elog!("Invalid field: {field}");
+                    }
+                    in_map
+                })
+                .collect::<Vec<_>>(),
+        ),
+        [pair] => (pair, VALID_FIELDS.to_vec()),
         _ => {
             elog!("Invalid input format");
             Process::error("Invalid input format".as_bytes());
             return Ok(());
         }
     };
-    log!("Fetching price for: {pair}, and using {field}");
 
-    // Log the asset being fetched as part of the Execution Standard Out.
-    log!("Fetching price for: {pair}");
+    if fields.is_empty() {
+        Process::error("No valid fields requested".as_bytes());
+    }
+
+    log!("Fetching price for: {pair}, and using {fields:?}");
 
     let url = [API_URL, pair].concat();
     let response = proxy_http_fetch(
@@ -88,15 +114,32 @@ pub fn execution_phase() -> Result<()> {
         &response.bytes,
     )?;
 
-    let price = response_data
-        .get(field)
-        .and_then(|price| price.as_str())
-        .ok_or_else(|| anyhow::anyhow!("{field} not found in response or is invalid"))?;
-    let price_lossless = make_price(price, 6)?;
-    log!("Fetched price: {price_lossless:?}");
+    let parsed_field_values: Vec<u8> = fields
+        .into_iter()
+        .flat_map(|field| {
+            let value = if field != "ts" {
+                let price = response_data
+                    .get(field)
+                    .and_then(|price| price.as_str())
+                    .ok_or_else(|| anyhow!("{field} not found in response or is invalid"))?;
+                let price_lossless = make_price(price, 6)?;
+                log!("Fetched {field}: {price_lossless:?}");
+                price_lossless.to_le_bytes()
+            } else {
+                let timestamp = response_data
+                    .get(field)
+                    .and_then(|ts| ts.as_u64())
+                    .ok_or_else(|| anyhow!("{field} not found in response or is invalid"))?;
+                log!("Fetched {field}: {timestamp:?}");
+                (timestamp as u128).to_le_bytes()
+            };
+            Ok::<_, anyhow::Error>(value)
+        })
+        .flatten()
+        .collect();
 
     // Report the successful result back to the SEDA network.
-    Process::success(&price_lossless.to_le_bytes());
+    Process::success(&parsed_field_values);
 
     Ok(())
 }

--- a/examples/blocksize-bidask/src/tally_phase.rs
+++ b/examples/blocksize-bidask/src/tally_phase.rs
@@ -1,33 +1,38 @@
 use anyhow::Result;
 use ethabi::{Token, ethereum_types::U256};
-use seda_sdk_rs::{Process, elog, get_reveals, log};
+use seda_sdk_rs::{Process, get_reveals, log};
 
 pub fn tally_phase() -> Result<()> {
     // Retrieve consensus reveals from the tally phase.
     let reveals = get_reveals()?;
-    let mut revealed_prices: Vec<u128> = Vec::with_capacity(reveals.len());
+    let mut revealed_fields: Vec<Vec<u128>> = Vec::with_capacity(reveals.len());
 
     // Iterate over each reveal, parse its content as an unsigned integer (u128), and store it in the prices array.
     for reveal in reveals {
-        let price = match reveal.body.reveal.as_slice().try_into() {
-            Ok(price) => u128::from_le_bytes(price),
-            Err(err) => {
-                elog!("Failed to parse revealed prices: {err}");
-                continue;
-            }
-        };
-
-        revealed_prices.push(price);
+        revealed_fields.push(
+            reveal
+                .body
+                .reveal
+                .as_slice()
+                .chunks_exact(size_of::<u128>())
+                .map(|chunk| {
+                    let arr: [u8; 16] = chunk
+                        .try_into()
+                        .map_err(|_| anyhow::anyhow!("invalid u128 bytes"))?;
+                    Ok::<_, anyhow::Error>(u128::from_le_bytes(arr))
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        );
     }
 
     // If no valid prices were revealed, report an error indicating no consensus.
-    if revealed_prices.is_empty() {
+    if revealed_fields.is_empty() {
         Process::error("No consensus among revealed results".as_bytes());
         return Ok(());
     }
 
     // If there are valid prices revealed, calculate the median price from price reports.
-    let final_prices = median(&revealed_prices);
+    let final_prices = median_each_field(&revealed_fields);
 
     log!("Final median prices: {final_prices:?}");
     // Encode the final median price as a EVM `uint256`.
@@ -38,26 +43,33 @@ pub fn tally_phase() -> Result<()> {
     Ok(())
 }
 
-/// Finds the median of a list of prices per price report.
-fn median(data: &[u128]) -> Token {
-    let m = data.len();
+/// Finds the median of a list preserving the order of the fields
+fn median_each_field(data: &[Vec<u128>]) -> Token {
+    let m = data[0].len();
 
-    if m == 0 {
-        Process::error("No valid data available for median calculation".as_bytes());
+    if !data.iter().all(|row| row.len() == m) {
+        Process::error("Inconsistent row lengths in data reveals".as_bytes());
     }
 
-    let mut sorted_data = data.to_vec();
-    sorted_data.sort_unstable();
+    let mut result = Vec::with_capacity(m);
+    (0..m).for_each(|col| {
+        // collect the col-th value from each reveal
+        let mut vals = Vec::with_capacity(data.len());
+        data.iter().for_each(|row| vals.push(row[col]));
+        vals.sort();
+        let mid = vals.len() / 2;
 
-    let median_price = if m % 2 == 0 {
-        // safe average of two u128s without overflow
-        let a = sorted_data[m / 2 - 1];
-        let b = sorted_data[m / 2];
-        a.midpoint(b)
-    } else {
-        sorted_data[m / 2]
-    };
+        let median_price = if vals.len() % 2 == 0 {
+            // safe average of two u128s without overflow
+            let a = vals[mid - 1];
+            let b = vals[mid];
+            a.midpoint(b)
+        } else {
+            vals[mid]
+        };
 
-    // convert to Token::Uint for encoding
-    Token::Uint(U256::from(median_price))
+        // convert to Token::Uint for encoding
+        result.push(Token::Uint(U256::from(median_price)));
+    });
+    Token::Array(result)
 }

--- a/examples/blocksize-vwap/README.md
+++ b/examples/blocksize-vwap/README.md
@@ -1,18 +1,18 @@
 # Blocksize Volume Weighted Average Price
 
 Deployments:
-- [Testnet](https://testnet.explorer.seda.xyz/oracle-programs/f51ac6b7212f5dd2ea639d27c62e79b76aa5e83a2b61a3bbb26f4bdcfb63d308)
+- [Testnet](https://testnet.explorer.seda.xyz/oracle-programs/5f4b8b833396c5aa2c705f2f67029f820cad81fe786b68f59aa43577a3323526)
 <!-- - [Mainnet](https://explorer.seda.xyz/oracle-programs/) -->
 
 
 ## Overview
 
-This Oracle Program gets the price of a price pair using the Blocksize API and returns the price in a format compatible with EVM smart contracts. The API is behind a Data Proxy.
+The Execution Phase expects a price pair symbol, and optionally the field from the response to use. By default it will use all the fields from the API response.
 
 You can test this Oracle Program on testnet with the following command:
 
 ```sh
-cargo post-dr blocksize-vwap BTCUSD -i f51ac6b7212f5dd2ea639d27c62e79b76aa5e83a2b61a3bbb26f4bdcfb63d308 --gas-price 4000
+cargo post-dr blocksize-vwap BTCUSD -i 5f4b8b833396c5aa2c705f2f67029f820cad81fe786b68f59aa43577a3323526 --gas-price 4000
 ```
 
 ## Execution Phase:
@@ -24,16 +24,32 @@ The Execution Phase expects a price pair symbol.
 ### Process
 
 1. Validates the Data Request execution argument is not empty.
+1. The inputs are validated.
 1. Makes a HTTP call to the Blocksize Data Proxy.
-1. Converts the decimal to a `u128` with 2 decimal precision.
-1. Returns the `u128` in little endian format.
+1. Converts the decimal to a `u128` with 6 decimal precision.
+2. Returns an array of bytes that is the fields in the specified order each in little endian format.
 
 ### Example
 
+
+#### With No Fields Specified
+
 Input: `BTCUSD`
 
-Output: `110695870722`
+Output: `[110772629556, 11160, 1236308948, 1757024761578]`
 
+
+#### With a Field Specified
+
+Input: `BTCUSD-price`
+
+Output: `[110772629556]`
+
+#### With a Fields Specified
+
+Input: `BTCUSD-ts,price`
+
+Output: `[1756147348689, 110772629556]`
 
 ## Tally Phase
 
@@ -46,20 +62,32 @@ No additional input is required for this Oracle Program as the Tally Phase only 
 1. Collects all price reveals from oracle nodes.
 1. Calculates the median price from all the given prices.
 1. ABI-encodes the result as a `uint256` for EVM compatibility.
-1. Posts the final result.
+1. Posts the final result preserving the order of the fields asked for.
 
 ### Output Format
 
-The result is ABI-encoded as `uint256` where the final number is the median of all the collected price data.
+The result is ABI-encoded as `uint256[]` where the final number is the median of all the collected price data.
 
 ### Example
 
 If execution phase ran with a replication factor of 2 and the prices were:
-- 100
-- 200
+- [100]
+- [200]
 
-The tally phase would return `150` ABI-encoded as a `uint256`.
+The tally phase would return `[150]` ABI-encoded as a `uint256[]`.
 
 ## Supported Data
 
 This supports any price pair supported by the [Blocksize API](https://realtime.blocksize.dev/docs#/VWAP).
+
+For quick reference, the JSON response is as follows:
+
+```JSON
+{
+  "ticker": "BTCUSD",
+  "price": 112269.91858575967,
+  "size": 4.5646076099999995,
+  "volume": 512468.12475063896,
+  "ts": 1756147348689
+}
+```

--- a/examples/blocksize-vwap/src/execution_phase.rs
+++ b/examples/blocksize-vwap/src/execution_phase.rs
@@ -26,22 +26,52 @@ pub fn execution_phase() -> Result<()> {
 //   "ts": 1756147348689
 // }
 
+const VALID_FIELDS: &[&str] = &["price", "size", "volume", "ts"];
+
 #[cfg(any(feature = "testnet", feature = "mainnet"))]
 pub fn execution_phase() -> Result<()> {
     #[cfg(feature = "mainnet")]
     unimplemented!("Mainnet not yet supported");
 
     // Expected to be in the format "symbol" (e.g., "ETHUSD" or "BTCUSD").
+    // Optionally followed by the field names (e.g., "price,size") separated by a hyphen(-).
     let dr_inputs_raw = String::from_utf8(Process::get_inputs())?;
     if dr_inputs_raw.is_empty() {
         // If no input is provided, log an error and return.
-        elog!("No input provided for the price pair request.");
+        elog!("No input provided for the equity price request.");
         Process::error("No input provided".as_bytes());
         return Ok(());
     }
 
-    // Log the asset being fetched as part of the Execution Standard Out.
-    log!("Fetching price for: {dr_inputs_raw}");
+    let parts: Vec<&str> = dr_inputs_raw.split('-').collect();
+    let (pair, fields) = match parts.as_slice() {
+        // validate that each field is in the valid fields list
+        [pair, fields] => (
+            pair,
+            fields
+                .split(',')
+                .filter(|field| {
+                    let in_map = VALID_FIELDS.contains(field);
+                    if !in_map {
+                        elog!("Invalid field: {field}");
+                    }
+                    in_map
+                })
+                .collect::<Vec<_>>(),
+        ),
+        [pair] => (pair, VALID_FIELDS.to_vec()),
+        _ => {
+            elog!("Invalid input format");
+            Process::error("Invalid input format".as_bytes());
+            return Ok(());
+        }
+    };
+
+    if fields.is_empty() {
+        Process::error("No valid fields requested".as_bytes());
+    }
+
+    log!("Fetching price for: {pair}, and using {fields:?}");
 
     let url = [API_URL, &dr_inputs_raw].concat();
     log!("Fetching URL: {url}");
@@ -63,15 +93,33 @@ pub fn execution_phase() -> Result<()> {
         &response.bytes,
     )?;
 
-    let price = response_data
-        .get("price")
-        .and_then(|price| price.as_f64())
-        .ok_or_else(|| anyhow::anyhow!("price not found in response or invalid"))?;
-    let price_lossless = make_price(&price.to_string(), 6)?;
-    log!("Fetched price: {price_lossless:?}");
+    let parsed_field_values: Vec<u8> = fields
+        .into_iter()
+        .flat_map(|field| {
+            log!("Processing field: {field}");
+            let value = if field != "ts" {
+                let price = response_data
+                    .get(field)
+                    .and_then(|price| price.as_f64())
+                    .ok_or_else(|| anyhow!("{field} not found in response or is invalid"))?;
+                let price_lossless = make_price(&price.to_string(), 6)?;
+                log!("Fetched {field}: {price_lossless:?}");
+                price_lossless.to_le_bytes()
+            } else {
+                let timestamp = response_data
+                    .get(field)
+                    .and_then(|ts| ts.as_u64())
+                    .ok_or_else(|| anyhow!("{field} not found in response or is invalid"))?;
+                log!("Fetched {field}: {timestamp:?}");
+                (timestamp as u128).to_le_bytes()
+            };
+            Ok::<_, anyhow::Error>(value)
+        })
+        .flatten()
+        .collect();
 
     // Report the successful result back to the SEDA network.
-    Process::success(&price_lossless.to_le_bytes());
+    Process::success(&parsed_field_values);
 
     Ok(())
 }

--- a/examples/blocksize-vwap/src/tally_phase.rs
+++ b/examples/blocksize-vwap/src/tally_phase.rs
@@ -1,33 +1,38 @@
 use anyhow::Result;
 use ethabi::{Token, ethereum_types::U256};
-use seda_sdk_rs::{Process, elog, get_reveals, log};
+use seda_sdk_rs::{Process, get_reveals, log};
 
 pub fn tally_phase() -> Result<()> {
     // Retrieve consensus reveals from the tally phase.
     let reveals = get_reveals()?;
-    let mut revealed_prices: Vec<u128> = Vec::with_capacity(reveals.len());
+    let mut revealed_fields: Vec<Vec<u128>> = Vec::with_capacity(reveals.len());
 
     // Iterate over each reveal, parse its content as an unsigned integer (u128), and store it in the prices array.
     for reveal in reveals {
-        let price = match reveal.body.reveal.as_slice().try_into() {
-            Ok(price) => u128::from_le_bytes(price),
-            Err(err) => {
-                elog!("Failed to parse revealed prices: {err}");
-                continue;
-            }
-        };
-
-        revealed_prices.push(price);
+        revealed_fields.push(
+            reveal
+                .body
+                .reveal
+                .as_slice()
+                .chunks_exact(size_of::<u128>())
+                .map(|chunk| {
+                    let arr: [u8; 16] = chunk
+                        .try_into()
+                        .map_err(|_| anyhow::anyhow!("invalid u128 bytes"))?;
+                    Ok::<_, anyhow::Error>(u128::from_le_bytes(arr))
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        );
     }
 
     // If no valid prices were revealed, report an error indicating no consensus.
-    if revealed_prices.is_empty() {
+    if revealed_fields.is_empty() {
         Process::error("No consensus among revealed results".as_bytes());
         return Ok(());
     }
 
     // If there are valid prices revealed, calculate the median price from price reports.
-    let final_prices = median(&revealed_prices);
+    let final_prices = median_each_field(&revealed_fields);
 
     log!("Final median prices: {final_prices:?}");
     // Encode the final median price as a EVM `uint256`.
@@ -38,26 +43,33 @@ pub fn tally_phase() -> Result<()> {
     Ok(())
 }
 
-/// Finds the median of a list of prices per price report.
-fn median(data: &[u128]) -> Token {
-    let m = data.len();
+/// Finds the median of a list preserving the order of the fields
+fn median_each_field(data: &[Vec<u128>]) -> Token {
+    let m = data[0].len();
 
-    if m == 0 {
-        Process::error("No valid data available for median calculation".as_bytes());
+    if !data.iter().all(|row| row.len() == m) {
+        Process::error("Inconsistent row lengths in data reveals".as_bytes());
     }
 
-    let mut sorted_data = data.to_vec();
-    sorted_data.sort_unstable();
+    let mut result = Vec::with_capacity(m);
+    (0..m).for_each(|col| {
+        // collect the col-th value from each reveal
+        let mut vals = Vec::with_capacity(data.len());
+        data.iter().for_each(|row| vals.push(row[col]));
+        vals.sort();
+        let mid = vals.len() / 2;
 
-    let median_price = if m % 2 == 0 {
-        // safe average of two u128s without overflow
-        let a = sorted_data[m / 2 - 1];
-        let b = sorted_data[m / 2];
-        a.midpoint(b)
-    } else {
-        sorted_data[m / 2]
-    };
+        let median_price = if vals.len() % 2 == 0 {
+            // safe average of two u128s without overflow
+            let a = vals[mid - 1];
+            let b = vals[mid];
+            a.midpoint(b)
+        } else {
+            vals[mid]
+        };
 
-    // convert to Token::Uint for encoding
-    Token::Uint(U256::from(median_price))
+        // convert to Token::Uint for encoding
+        result.push(Token::Uint(U256::from(median_price)));
+    });
+    Token::Array(result)
 }

--- a/examples/tests/blocksize-vwap.test.ts
+++ b/examples/tests/blocksize-vwap.test.ts
@@ -3,8 +3,8 @@ import { file } from 'bun';
 import { afterEach, describe, it, mock } from 'bun:test';
 import { testOracleProgramExecution, testOracleProgramTally } from '@seda-protocol/dev-tools';
 import {
-  handleBigIntTallyVmResult as handleVmResult,
-  handleBigIntExecutionVmResult as handleExecutionVmResult,
+  handleBigIntArrayTallyVmResult as handleVmResult,
+  handleBigIntArrayExecutionVmResult as handleExecutionVmResult,
   createRevealArray,
   RevealKind,
 } from './utils.js';
@@ -17,7 +17,7 @@ afterEach(() => {
   fetchMock.mockRestore();
 });
 
-describe('single price feed', () => {
+describe('blocksize vwap', () => {
   describe('execution phase', () => {
     it('works', async () => {
       fetchMock.mockImplementation((_) => {
@@ -43,8 +43,122 @@ describe('single price feed', () => {
         undefined,
         0n,
       );
+      console.log('VM Result:', vmResult);
 
-      handleExecutionVmResult(vmResult, 0, 112269918585n);
+      handleExecutionVmResult(vmResult, 0, [112269918585n, 4564607n, 512468124750n, 1756147348689n]);
+    });
+
+    it('works with a singular specified field', async () => {
+      fetchMock.mockImplementation((_) => {
+        return new Response(
+          JSON.stringify({
+            ticker: 'BTCUSD',
+            price: 112269.91858575967,
+            size: 4.5646076099999995,
+            volume: 512468.12475063896,
+            ts: 1756147348689,
+          }),
+        );
+      });
+
+      const oracleProgram = await file(WASM_PATH).arrayBuffer();
+
+      const vmResult = await testOracleProgramExecution(
+        Buffer.from(oracleProgram),
+        Buffer.from('BTCUSD-size'),
+        fetchMock,
+        undefined,
+        undefined,
+        undefined,
+        0n,
+      );
+
+      handleExecutionVmResult(vmResult, 0, [4564607n]);
+    });
+
+    it('works with a multi specified field and returns in the specified order', async () => {
+      fetchMock.mockImplementation((_) => {
+        return new Response(
+          JSON.stringify({
+            ticker: 'BTCUSD',
+            price: 112269.91858575967,
+            size: 4.5646076099999995,
+            volume: 512468.12475063896,
+            ts: 1756147348689,
+          }),
+        );
+      });
+
+      const oracleProgram = await file(WASM_PATH).arrayBuffer();
+
+      const vmResult = await testOracleProgramExecution(
+        Buffer.from(oracleProgram),
+        Buffer.from('BTCUSD-ts,price'),
+        fetchMock,
+        undefined,
+        undefined,
+        undefined,
+        0n,
+      );
+
+      handleExecutionVmResult(vmResult, 0, [1756147348689n, 112269918585n]);
+    });
+
+    it('ignores if a non-existent field is requested', async () => {
+      fetchMock.mockImplementation((_) => {
+        return new Response(
+          JSON.stringify({
+            ticker: 'BTCUSD',
+            price: 112269.91858575967,
+            size: 4.5646076099999995,
+            volume: 512468.12475063896,
+            ts: 1756147348689,
+          }),
+        );
+      });
+
+      const oracleProgram = await file(WASM_PATH).arrayBuffer();
+
+      const vmResult = await testOracleProgramExecution(
+        Buffer.from(oracleProgram),
+        Buffer.from('BTCUSD-does_not_exist,price'),
+        fetchMock,
+        undefined,
+        undefined,
+        undefined,
+        0n,
+      );
+      console.log('VM Result:', vmResult);
+
+      handleExecutionVmResult(vmResult, 0, [112269918585n]);
+    });
+
+    it('errors if no valid fields are selected', async () => {
+      fetchMock.mockImplementation((_) => {
+        return new Response(
+          JSON.stringify({
+            ticker: 'BTCUSD',
+            price: 112269.91858575967,
+            size: 4.5646076099999995,
+            volume: 512468.12475063896,
+            ts: 1756147348689,
+          }),
+        );
+      });
+
+      const oracleProgram = await file(WASM_PATH).arrayBuffer();
+
+      const vmResult = await testOracleProgramExecution(
+        Buffer.from(oracleProgram),
+        Buffer.from('BTCUSD-does_not_exist'),
+        fetchMock,
+        undefined,
+        undefined,
+        undefined,
+        0n,
+      );
+
+      handleExecutionVmResult(vmResult, 1, []);
     });
   });
 
@@ -54,9 +168,22 @@ describe('single price feed', () => {
       const vmResult = await testOracleProgramTally(
         Buffer.from(oracleProgram),
         Buffer.from('tally-inputs'),
-        createRevealArray([[RevealKind.BigInt, 100n]]),
+        createRevealArray([[RevealKind.BigIntArray, [100n]]]),
       );
-      handleVmResult(vmResult, 0, 100n);
+      handleVmResult(vmResult, 0, [100n]);
+    });
+
+    it('works with 1 price and multiple fields', async () => {
+      const oracleProgram = await file(WASM_PATH).arrayBuffer();
+      const vmResult = await testOracleProgramTally(
+        Buffer.from(oracleProgram),
+        Buffer.from('tally-inputs'),
+        createRevealArray([
+          [RevealKind.BigIntArray, [100n]],
+          [RevealKind.BigIntArray, [200n]],
+        ]),
+      );
+      handleVmResult(vmResult, 0, [150n]);
     });
 
     it('works with 2 prices', async () => {
@@ -65,11 +192,25 @@ describe('single price feed', () => {
         Buffer.from(oracleProgram),
         Buffer.from('tally-inputs'),
         createRevealArray([
-          [RevealKind.BigInt, 100n],
-          [RevealKind.BigInt, 200n],
+          [RevealKind.BigIntArray, [100n]],
+          [RevealKind.BigIntArray, [200n]],
         ]),
       );
-      handleVmResult(vmResult, 0, 150n);
+      handleVmResult(vmResult, 0, [150n]);
+    });
+
+    it('works with 2 prices with multiple fields', async () => {
+      const oracleProgram = await file(WASM_PATH).arrayBuffer();
+      const vmResult = await testOracleProgramTally(
+        Buffer.from(oracleProgram),
+        Buffer.from('tally-inputs'),
+        createRevealArray([
+          [RevealKind.BigIntArray, [100n, 500n]],
+          [RevealKind.BigIntArray, [300n, 900n]],
+          [RevealKind.BigIntArray, [200n, 700n]],
+        ]),
+      );
+      handleVmResult(vmResult, 0, [200n, 700n]);
     });
 
     it('works with 5 prices', async () => {
@@ -78,14 +219,14 @@ describe('single price feed', () => {
         Buffer.from(oracleProgram),
         Buffer.from('tally-inputs'),
         createRevealArray([
-          [RevealKind.BigInt, 100n],
-          [RevealKind.BigInt, 200n],
-          [RevealKind.BigInt, 300n],
-          [RevealKind.BigInt, 400n],
-          [RevealKind.BigInt, 500n],
+          [RevealKind.BigIntArray, [100n]],
+          [RevealKind.BigIntArray, [200n]],
+          [RevealKind.BigIntArray, [300n]],
+          [RevealKind.BigIntArray, [400n]],
+          [RevealKind.BigIntArray, [500n]],
         ]),
       );
-      handleVmResult(vmResult, 0, 300n);
+      handleVmResult(vmResult, 0, [300n]);
     });
 
     it('works with 10 prices', async () => {
@@ -94,19 +235,19 @@ describe('single price feed', () => {
         Buffer.from(oracleProgram),
         Buffer.from('tally-inputs'),
         createRevealArray([
-          [RevealKind.BigInt, 100n],
-          [RevealKind.BigInt, 200n],
-          [RevealKind.BigInt, 300n],
-          [RevealKind.BigInt, 400n],
-          [RevealKind.BigInt, 500n],
-          [RevealKind.BigInt, 600n],
-          [RevealKind.BigInt, 700n],
-          [RevealKind.BigInt, 800n],
-          [RevealKind.BigInt, 900n],
-          [RevealKind.BigInt, 1000n],
+          [RevealKind.BigIntArray, [100n]],
+          [RevealKind.BigIntArray, [200n]],
+          [RevealKind.BigIntArray, [300n]],
+          [RevealKind.BigIntArray, [400n]],
+          [RevealKind.BigIntArray, [500n]],
+          [RevealKind.BigIntArray, [600n]],
+          [RevealKind.BigIntArray, [700n]],
+          [RevealKind.BigIntArray, [800n]],
+          [RevealKind.BigIntArray, [900n]],
+          [RevealKind.BigIntArray, [1000n]],
         ]),
       );
-      handleVmResult(vmResult, 0, 550n);
+      handleVmResult(vmResult, 0, [550n]);
     });
 
     it('works with unsorted prices', async () => {
@@ -115,15 +256,15 @@ describe('single price feed', () => {
         Buffer.from(oracleProgram),
         Buffer.from('tally-inputs'),
         createRevealArray([
-          [RevealKind.BigInt, 500n],
-          [RevealKind.BigInt, 100n],
-          [RevealKind.BigInt, 300n],
-          [RevealKind.BigInt, 200n],
-          [RevealKind.BigInt, 200n],
-          [RevealKind.BigInt, 400n],
+          [RevealKind.BigIntArray, [500n]],
+          [RevealKind.BigIntArray, [100n]],
+          [RevealKind.BigIntArray, [300n]],
+          [RevealKind.BigIntArray, [200n]],
+          [RevealKind.BigIntArray, [200n]],
+          [RevealKind.BigIntArray, [400n]],
         ]),
       );
-      handleVmResult(vmResult, 0, 250n);
+      handleVmResult(vmResult, 0, [250n]);
     });
 
     describe('works with errored executions', () => {
@@ -133,10 +274,10 @@ describe('single price feed', () => {
         const vmResult = await testOracleProgramTally(
           Buffer.from(oracleProgram),
           Buffer.from('tally-inputs'),
-          createRevealArray([[RevealKind.BigInt, 100n], [RevealKind.Failed], [RevealKind.BigInt, 200n]]),
+          createRevealArray([[RevealKind.BigIntArray, [100n]], [RevealKind.Failed], [RevealKind.BigIntArray, [200n]]]),
         );
 
-        handleVmResult(vmResult, 0, 150n);
+        handleVmResult(vmResult, 0, [150n]);
       });
 
       it('should ignore multiple errored executions', async () => {
@@ -146,15 +287,15 @@ describe('single price feed', () => {
           Buffer.from(oracleProgram),
           Buffer.from('tally-inputs'),
           createRevealArray([
-            [RevealKind.BigInt, 100n],
+            [RevealKind.BigIntArray, [100n]],
             [RevealKind.Failed],
-            [RevealKind.BigInt, 200n],
+            [RevealKind.BigIntArray, [200n]],
             [RevealKind.Failed],
-            [RevealKind.BigInt, 300n],
+            [RevealKind.BigIntArray, [300n]],
           ]),
         );
 
-        handleVmResult(vmResult, 0, 200n);
+        handleVmResult(vmResult, 0, [200n]);
       });
 
       it('should error if all executions errored', async () => {
@@ -165,7 +306,7 @@ describe('single price feed', () => {
           createRevealArray([[RevealKind.Failed], [RevealKind.Failed], [RevealKind.Failed]]),
         );
 
-        handleVmResult(vmResult, 1, 0n);
+        handleVmResult(vmResult, 1, []);
       });
     });
   });

--- a/examples/tests/caplight-eod-market-price.test.ts
+++ b/examples/tests/caplight-eod-market-price.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
   fetchMock.mockRestore();
 });
 
-describe('single commodity price', () => {
+describe('caplight eod market price', () => {
   describe('execution phase', () => {
     it('works', async () => {
       fetchMock.mockImplementation((_) => {

--- a/examples/tests/single-equity-price-verification.test.ts
+++ b/examples/tests/single-equity-price-verification.test.ts
@@ -19,7 +19,7 @@ afterEach(() => {
   fetchMock.mockRestore();
 });
 
-describe('single price feed', () => {
+describe('single equity price verification', () => {
   describe('execution phase', () => {
     it('works', async () => {
       const responseBody = {

--- a/examples/tests/single-price-feed-verification.test.ts
+++ b/examples/tests/single-price-feed-verification.test.ts
@@ -19,7 +19,7 @@ afterEach(() => {
   fetchMock.mockRestore();
 });
 
-describe('single price feed', () => {
+describe('single price feed verification', () => {
   describe('execution phase', () => {
     it('works', async () => {
       const responseBody = {

--- a/examples/tests/us-rates.test.ts
+++ b/examples/tests/us-rates.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
   fetchMock.mockRestore();
 });
 
-describe('single price feed', () => {
+describe('us rates', () => {
   describe('execution phase', () => {
     it('works', async () => {
       fetchMock

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -243,7 +243,7 @@ fn try_main() -> Result<()> {
                 OracleProgram::SingleEquityPriceVerification,
                 OracleProgram::MultiPriceFeed,
                 OracleProgram::SinglePriceFeed,
-                OracleProgram::SingleEquityPriceVerification,
+                OracleProgram::SinglePriceFeedVerification,
                 OracleProgram::EvmPriceFeed,
                 OracleProgram::UsRates,
                 OracleProgram::BlocksizeBidask,
@@ -407,7 +407,7 @@ fn post_blocksize_bidask(cmd: Cmd<'_>, symbol: &str) -> std::result::Result<(), 
     cmd.arg("--exec-inputs")
         .arg(symbol)
         .arg("--decode-abi")
-        .arg("uint256")
+        .arg("uint256[]")
         .run()?;
     Ok(())
 }
@@ -416,7 +416,7 @@ fn post_blocksize_vwap(cmd: Cmd<'_>, pair: &str) -> std::result::Result<(), anyh
     cmd.arg("--exec-inputs")
         .arg(pair)
         .arg("--decode-abi")
-        .arg("uint256")
+        .arg("uint256[]")
         .run()?;
     Ok(())
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Make the changes blocksize asked for.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

You can now pass in the fields you want from the API response. By default, does all fields from the response, minus the ticker.
It does the median for each, and it returns an `uint256[]`.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Modified the tests and tested on testnet.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A
